### PR TITLE
New Unity Version fixes

### DIFF
--- a/source/Assets/Plugins/Didomi/Editor/PostProcessor.cs
+++ b/source/Assets/Plugins/Didomi/Editor/PostProcessor.cs
@@ -31,6 +31,7 @@ class PostProcessorGradleAndroidProject : IPostGenerateGradleAndroidProject
     {
         UpdateUnityPlayerActivity(path);
         UpdateUnityLibraryDependencies(path);
+        UpdateGradleProperties(path);
         CopyDidomiConfigFileToAssetFolder(path);
         CopyPackageJsonFileToAssetFolder(path);
         UpdateStylesThemeToAppCompat(path);
@@ -143,6 +144,26 @@ class PostProcessorGradleAndroidProject : IPostGenerateGradleAndroidProject
     implementation(""org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"")
     implementation(""org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.4.2"")";
         PostProcessor.ReplaceLineInFile(unityPlayerFileAbsolutePath, oldValue, newValue);
+    }
+
+    /// <summary>
+    /// Update gradle properties in the Android project. 
+    /// </summary>
+    /// <param name="path"></param>
+    private static void UpdateGradleProperties(string path)
+    {
+        var unityGradleProperties = $@"..{PostProcessorSettings.FilePathSeperator}gradle.properties";
+        var unityGradleAbsolutePath = Path.Combine(path, unityGradleProperties);
+        var gradleProperties = File.ReadAllText(unityGradleAbsolutePath);
+
+        if (gradleProperties.Contains("android.useAndroidX=false"))
+        {
+            PostProcessorSettings.ReplaceLineInFile(unityGradleAbsolutePath, "android.useAndroidX=false", "android.useAndroidX=true");
+        }
+        else if (!gradleProperties.Contains("android.useAndroidX=true"))
+        {
+            File.AppendAllText(unityGradleAbsolutePath, System.Environment.NewLine + "android.useAndroidX=true");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
android.useAndroidX=true to gradle.properties. Recent unity versions require the attribute.