### PR TITLE
Fix error when getting UserStatus on iOS

### DIFF
--- a/source/Assets/Plugins/Didomi/Scripts/IOS/IOSObjectMapper.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/IOS/IOSObjectMapper.cs
@@ -80,6 +80,8 @@ namespace IO.Didomi.SDK.IOS
 
         public class JsonSetStringConverter : JsonConverter<ISet<string>>
         {
+            public JsonSetStringConverter() { }
+
             public override ISet<string> ReadJson(JsonReader reader, Type objectType, ISet<string> existingValue, bool hasExistingValue, JsonSerializer serializer)
             {
                 ISet<string> result = null;


### PR DESCRIPTION
A developer reported the following error on iOS:

```
Newtonsoft.Json.JsonException: Error creating 'IO.Didomi.SDK.IOS.IOSObjectMapper+JsonSetStringConverter'. ---> Newtonsoft.Json.JsonException: No parameterless constructor defined for 'IO.Didomi.SDK.IOS.IOSObjectMapper+JsonSetStringConverter'.
  at Newtonsoft.Json.Serialization.JsonTypeReflector+<>c__DisplayClass22_0.<GetCreator>b__0 (System.Object[] parameters) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Func`2[T,TResult].Invoke (T arg) [0x00000] in <00000000000000000000000000000000>:0 
  at Newtonsoft.Json.Serialization.JsonTypeReflector.GetJsonConverter (System.Object attributeProvider) [0x00000] in <00000000000000000000000000000000>:0 
  at Newtonsoft.Json.Serialization.DefaultContractResolver.SetPropertySettingsFromAttributes (Newtonsoft.Json.Serialization.JsonProperty property, System.Object attributeProvider, System.String name, System.Type declaringType, Newtonsoft.Json.MemberSerialization memberSerialization, System.Boolean& allowNonPublicAccess) [0x00000] in <0000000000000<…>
```

We did not reproduce the issue, which seems related to Newtonsoft plugin version (json parsing / serialization).

Adding a parameterless constructor to `JsonSetStringConverter` should fix the issue.