### PR TITLE
Add tests for share consents

### DIFF
--- a/source/Assets/Plugins/Didomi/Tests/DidomiBaseTests.cs
+++ b/source/Assets/Plugins/Didomi/Tests/DidomiBaseTests.cs
@@ -1,0 +1,65 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using IO.Didomi.SDK;
+using System;
+
+/// <summary>
+/// Provide base methods that can be used in all tests
+/// </summary>
+public class DidomiBaseTests
+{
+    private bool sdkReady = false;
+
+    /// <summary>
+    /// Load SDK and wait until initialization is ready
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerator LoadSdk()
+    {
+        try
+        {
+            string apiKey = "c3cd5b46-bf36-4700-bbdc-4ee9176045aa";
+
+            Debug.Log("Tests: Initializing sdk");
+
+            Didomi didomi = Didomi.GetInstance();
+
+            didomi.Initialize(new DidomiInitializeParameters(apiKey, disableDidomiRemoteConfig: true));
+
+            didomi.OnReady(
+                () =>
+                {
+                    sdkReady = true;
+                }
+                );
+            didomi.OnError(
+                () =>
+                {
+                    sdkReady = true;
+                }
+                );
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"Exception : {ex.Message}");
+        }
+
+        yield return WaitForSdkReady();
+    }
+
+    /**
+     * Wait until SDK is ready and Reset the consents
+     */
+    public IEnumerator WaitForSdkReady()
+    {
+        Debug.Log("Tests: Waiting for sdk ready");
+
+        yield return new WaitUntil(() => sdkReady);
+
+        Assert.True(Didomi.GetInstance().IsReady());
+        Debug.Log("Tests: sdk is ready!");
+
+        Didomi.GetInstance().Reset();
+    }
+}

--- a/source/Assets/Plugins/Didomi/Tests/DidomiBaseTests.cs.meta
+++ b/source/Assets/Plugins/Didomi/Tests/DidomiBaseTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f1e2393b868543ecbe93bbbc0ad0084
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorListsTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorListsTestsSuite.cs
@@ -9,10 +9,8 @@ using IO.Didomi.SDK;
 /// </summary>
 public class PurposeAndVendorListsTestsSuite: DidomiBaseTests
 {
-    private bool sdkReady = false;
-
     [UnitySetUp]
-    public IEnumerator setup()
+    public IEnumerator Setup()
     {
         yield return LoadSdk();
     }

--- a/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorListsTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorListsTestsSuite.cs
@@ -1,74 +1,33 @@
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
-using UnityEngine;
 using UnityEngine.TestTools;
 using IO.Didomi.SDK;
-using System;
 
-public class DidomiTestsSuite
+/// <summary>
+/// Tests related to lists of purpose and vendor loaded into SDK
+/// </summary>
+public class PurposeAndVendorListsTestsSuite: DidomiBaseTests
 {
     private bool sdkReady = false;
 
-    [SetUp]
-    public void setup()
+    [UnitySetUp]
+    public IEnumerator setup()
     {
-        try
-        {
-            string apiKey = "c3cd5b46-bf36-4700-bbdc-4ee9176045aa";
-            string noticeId = null;
-            string localConfigurationPath = null;
-            string remoteConfigurationURL = null;
-            string providerId = null;
-            bool disableDidomiRemoteConfig = true;
-            string languageCode = null;
-
-            Debug.Log("Tests: Initializing sdk");
-
-            Didomi didomi = Didomi.GetInstance();
-
-            didomi.Initialize(
-                apiKey,
-                localConfigurationPath,
-                remoteConfigurationURL,
-                providerId,
-                disableDidomiRemoteConfig,
-                languageCode,
-                noticeId);
-
-            didomi.OnReady(
-                () =>
-                {
-                    sdkReady = true;
-                }
-                );
-            didomi.OnError(
-                () =>
-                {
-                    sdkReady = true;
-                }
-                );
-        }
-        catch (Exception ex)
-        {
-            Debug.LogError($"Exception : {ex.Message}");
-        }
+        yield return LoadSdk();
     }
 
-    [UnityTest]
-    public IEnumerator TestPurposesAndVendorsCountAfterReset()
+    [Test]
+    public void TestPurposesAndVendorsCountAfterReset()
     {
-        yield return WaitForSdkReady();
-
         AssertHasRequiredPurposesAndVendors(true);
         AssertHasEnabledPurposesAndVendors(false);
         AssertHasDisabledPurposesAndVendors(false);
     }
 
-    [UnityTest]
-    public IEnumerator TestPurposesAndVendorsCountAfterUserAgreeToAll()
+    [Test]
+    public void TestPurposesAndVendorsCountAfterUserAgreeToAll()
     {
-        yield return WaitForSdkReady();
         Didomi.GetInstance().SetUserAgreeToAll();
 
         AssertHasRequiredPurposesAndVendors(true);
@@ -76,30 +35,14 @@ public class DidomiTestsSuite
         AssertHasDisabledPurposesAndVendors(false);
     }
 
-    [UnityTest]
-    public IEnumerator TestPurposesAndVendorsCountAfterUserDisagreeToAll()
+    [Test]
+    public void TestPurposesAndVendorsCountAfterUserDisagreeToAll()
     {
-        yield return WaitForSdkReady();
         Didomi.GetInstance().SetUserDisagreeToAll();
 
         AssertHasRequiredPurposesAndVendors(true);
         AssertHasEnabledPurposesAndVendors(false);
         AssertHasDisabledPurposesAndVendors(true);
-    }
-
-    /**
-     * Wait until SDK is ready and Reset the consents
-     */
-    public IEnumerator WaitForSdkReady()
-    {
-        Debug.Log("Tests: Waiting for sdk ready");
-
-        yield return new WaitUntil(() => sdkReady);
-
-        Assert.True(Didomi.GetInstance().IsReady());
-        Debug.Log("Tests: sdk is ready!");
-
-        Didomi.GetInstance().Reset();
     }
 
     /**

--- a/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorListsTestsSuite.cs.meta
+++ b/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorListsTestsSuite.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b86d23502ed544d079979c72b1007e66
+guid: f3006ce4c7f1d4538aa47a690f8beacd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using IO.Didomi.SDK;
+
+/// <summary>
+/// Tests related to sharing consent with Webview / Web SDK
+/// </summary>
+public class ShareConsentsTestSuite: DidomiBaseTests
+{
+    private bool sdkReady = false;
+
+    [UnitySetUp]
+    public IEnumerator setup()
+    {
+        yield return LoadSdk();
+    }
+
+    [Test]
+    public void TestGetJavaScriptForWebView()
+    {
+        var jsString = Didomi.GetInstance().GetJavaScriptForWebView();
+
+        Debug.Log("JS String = " + jsString);
+        
+        Assert.IsFalse(string.IsNullOrWhiteSpace(jsString));
+    }
+}

--- a/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs
@@ -9,10 +9,8 @@ using IO.Didomi.SDK;
 /// </summary>
 public class ShareConsentsTestSuite: DidomiBaseTests
 {
-    private bool sdkReady = false;
-
     [UnitySetUp]
-    public IEnumerator setup()
+    public IEnumerator Setup()
     {
         yield return LoadSdk();
     }

--- a/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs
@@ -20,10 +20,7 @@ public class ShareConsentsTestSuite: DidomiBaseTests
     [Test]
     public void TestGetJavaScriptForWebView()
     {
-        var jsString = Didomi.GetInstance().GetJavaScriptForWebView();
-
-        Debug.Log("JS String = " + jsString);
-        
-        Assert.IsFalse(string.IsNullOrWhiteSpace(jsString));
+        var jsString = Didomi.GetInstance().GetJavaScriptForWebView();        
+        Assert.IsTrue(jsString != null && jsString.Contains("window.didomiOnReady"));
     }
 }

--- a/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs.meta
+++ b/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 894359db9e57d4742a948e1aa685e76c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Refactor tests to add a Base test class, add tests related to sharing consent with Web SDK

Note: `[SetUp]` / `[Test]` annotations are for synchronous test methods, `[UnitySetUp]` / `[UnityTest]` annotations are for asynchronous methods (using `yield return` / `IEnumator`)