### PR TITLE
Add tests for Purpose and Vendor models

### DIFF
--- a/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorTestsSuite.cs
@@ -1,0 +1,78 @@
+using System.Collections;
+using System.Linq;
+using IO.Didomi.SDK;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class PurposeAndVendorTestsSuite: DidomiBaseTests
+{
+
+    [UnitySetUp]
+    public IEnumerator Setup()
+    {
+        yield return LoadSdk();
+    }
+
+    [Test]
+    public void TestGetPurpose()
+    {
+        // Purpose model not available on iOS
+        if (Application.platform == RuntimePlatform.Android)
+        {
+            var purposeId = GetFirstRequiredPurposeId();
+            Assert.False(string.IsNullOrEmpty(purposeId));
+
+            var purpose = Didomi.GetInstance().GetPurpose(purposeId);
+            Assert.AreEqual(purposeId, purpose?.GetId());
+        }
+        else
+        {
+            Assert.Inconclusive("Test only valid for Android platform");
+        }
+    }
+
+    [Test]
+    public void TestGetVendor()
+    {
+        // Vendor model not available on iOS
+        if (Application.platform == RuntimePlatform.Android)
+        {
+            var vendorId = GetFirstRequiredVendorId();
+            Assert.False(string.IsNullOrEmpty(vendorId));
+            
+            var vendor = Didomi.GetInstance().GetVendor(vendorId);
+            Assert.AreEqual(vendorId, vendor?.GetId());
+        }
+        else
+        {
+            Assert.Inconclusive("Test only valid for Android platform");
+        }
+    }
+
+    private string GetFirstRequiredPurposeId()
+    {
+        var requiredPurposeIdSet = Didomi.GetInstance().GetRequiredPurposeIds();
+
+        var purposeId = string.Empty;
+        if (requiredPurposeIdSet.Count > 0)
+        {
+            purposeId = requiredPurposeIdSet.FirstOrDefault();
+        }
+
+        return purposeId;
+    }
+
+    private string GetFirstRequiredVendorId()
+    {
+        var requiredVendorIdSet = Didomi.GetInstance().GetRequiredVendorIds();
+
+        var vendorId = string.Empty;
+        if (requiredVendorIdSet.Count > 0)
+        {
+            vendorId = requiredVendorIdSet.FirstOrDefault();
+        }
+
+        return vendorId;
+    }
+}

--- a/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorTestsSuite.cs.meta
+++ b/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorTestsSuite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 021eb8f89ff1e4de98773440d98cf1ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using NUnit.Framework;
-using UnityEngine;
 using UnityEngine.TestTools;
 using IO.Didomi.SDK;
 

--- a/source/Assets/Plugins/Didomi/Tests/SyncUserBaseTests.cs
+++ b/source/Assets/Plugins/Didomi/Tests/SyncUserBaseTests.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.TestTools;
 using IO.Didomi.SDK;
 using IO.Didomi.SDK.Events;
 


### PR DESCRIPTION
Add tests for Purpose and Vendor models. The feature and related tests are only available on Android.