### PR TITLE
Add UI automated tests

### DIFF
--- a/source/Assets/Plugins/Didomi/IOS/Didomi.mm
+++ b/source/Assets/Plugins/Didomi/IOS/Didomi.mm
@@ -201,7 +201,7 @@ bool isNoticeVisible()
 
 void showPreferences()
 {
-	[[Didomi shared] showPreferencesWithController:(nil) view:(ViewsPurposes)];
+	[[Didomi shared] showPreferencesWithController:(UnityGetGLViewController()) view:(ViewsPurposes)];
 }
 
 bool isUserConsentStatusPartial()

--- a/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorTestsSuite.cs
@@ -21,7 +21,7 @@ public class PurposeAndVendorTestsSuite: DidomiBaseTests
         if (Application.platform == RuntimePlatform.Android)
         {
             var purposeId = GetFirstRequiredPurposeId();
-            Assert.False(string.IsNullOrEmpty(purposeId));
+            Assert.False(string.IsNullOrEmpty(purposeId), "Invalid 1st purpose");
 
             var purpose = Didomi.GetInstance().GetPurpose(purposeId);
             Assert.AreEqual(purposeId, purpose?.GetId());
@@ -39,7 +39,7 @@ public class PurposeAndVendorTestsSuite: DidomiBaseTests
         if (Application.platform == RuntimePlatform.Android)
         {
             var vendorId = GetFirstRequiredVendorId();
-            Assert.False(string.IsNullOrEmpty(vendorId));
+            Assert.False(string.IsNullOrEmpty(vendorId), "Invalid 1st vendor");
             
             var vendor = Didomi.GetInstance().GetVendor(vendorId);
             Assert.AreEqual(vendorId, vendor?.GetId());

--- a/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/ShareConsentsTestsSuite.cs
@@ -17,7 +17,7 @@ public class ShareConsentsTestsSuite: DidomiBaseTests
     [Test]
     public void TestGetJavaScriptForWebView()
     {
-        var jsString = Didomi.GetInstance().GetJavaScriptForWebView();        
-        Assert.IsTrue(jsString != null && jsString.Contains("window.didomiOnReady"));
+        var jsString = Didomi.GetInstance().GetJavaScriptForWebView();
+        Assert.IsTrue(jsString != null && jsString.Contains("window.didomiOnReady"), $"Wrong jsString: {jsString}");
     }
 }

--- a/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs
@@ -54,7 +54,7 @@ public class UITestsSuite: DidomiBaseTests
 
         yield return new WaitForSeconds(1);
         Assert.True(Didomi.GetInstance().IsNoticeVisible(), "Notice should be visible");
-        CheckEvents("Called SetupUI", expectNoticeDisplayed: true);
+        AssertEvents("Called SetupUI", expectNoticeDisplayed: true);
     }
 
     [UnityTest]
@@ -66,14 +66,14 @@ public class UITestsSuite: DidomiBaseTests
         Didomi.GetInstance().ShowNotice();
         yield return new WaitForSeconds(1);
         Assert.True(Didomi.GetInstance().IsNoticeVisible(), "Notice should be visible");
-        CheckEvents("Called ShowNotice", expectNoticeDisplayed: true);
+        AssertEvents("Called ShowNotice", expectNoticeDisplayed: true);
 
         ResetEvents();
 
         Didomi.GetInstance().HideNotice();
         yield return new WaitForSeconds(1);
         Assert.False(Didomi.GetInstance().IsNoticeVisible(), "Notice should not be visible anymore");
-        CheckEvents("Called HideNotice", expectNoticeHidden: true);
+        AssertEvents("Called HideNotice", expectNoticeHidden: true);
     }
 
     [UnityTest]
@@ -83,7 +83,7 @@ public class UITestsSuite: DidomiBaseTests
         yield return new WaitForSeconds(1);
         Assert.False(Didomi.GetInstance().IsNoticeVisible(), "Notice should not be visible");
         Assert.True(Didomi.GetInstance().IsPreferencesVisible(), "Preferences screen should be visible");
-        CheckEvents("Called ShowPreferences", expectPreferencesDisplayed: true);
+        AssertEvents("Called ShowPreferences", expectPreferencesDisplayed: true);
 
         ResetEvents();
 
@@ -91,7 +91,7 @@ public class UITestsSuite: DidomiBaseTests
         yield return new WaitForSeconds(1);
         Assert.False(Didomi.GetInstance().IsNoticeVisible(), "Notice should still not be visible");
         Assert.False(Didomi.GetInstance().IsPreferencesVisible(), "Preferences screen should not be visible anymore");
-        CheckEvents("Called HidePreferences", expectPreferencesHidden: true);
+        AssertEvents("Called HidePreferences", expectPreferencesHidden: true);
     }
 
     private void EventListener_ShowNotice(object sender, ShowNoticeEvent e)
@@ -132,7 +132,10 @@ public class UITestsSuite: DidomiBaseTests
         ResetEvents();
     }
 
-    private void CheckEvents(
+    /**
+     * Checks if events were called as expected
+     */ 
+    private void AssertEvents(
         string message,
         bool expectNoticeDisplayed = false,
         bool expectNoticeHidden = false,
@@ -144,5 +147,4 @@ public class UITestsSuite: DidomiBaseTests
         Assert.AreEqual(expectPreferencesDisplayed, preferencesDisplayedEvent, $"{message} - Issue with ShowPreferences event");
         Assert.AreEqual(expectPreferencesHidden, preferencesHiddenEvent, $"{message} - Issue with HidePreferences event");
     }
-
 }

--- a/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs.meta
+++ b/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f157a16f1ec2d43d694a5c55c51a0e40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Add automated tests for UI elements
- Allow to call ShowPreferences without calling SetupUI on iOS (was already the case on Android)
- Add failure messages in other tests assertions, as Unity Test framework doesn't give enough information by itself when a test fails