### PR TITLE
Avoid returning bool from objective-C to C#

### DIFF
--- a/source/Assets/Plugins/Didomi/IOS/Didomi.mm
+++ b/source/Assets/Plugins/Didomi/IOS/Didomi.mm
@@ -125,9 +125,14 @@ void initializeWithParameters(char* apiKey, char* localConfigurationPath, char* 
     [[Didomi shared] initialize: parameters];
 }
 
-bool isReady()
+int convertBoolToInt(bool value)
 {
-	return [[Didomi shared] isReady];
+    return value ? 1 : 0;
+}
+
+int isReady()
+{
+    return convertBoolToInt([[Didomi shared] isReady]);
 }
 
 char* getTranslatedText(char* key)
@@ -184,29 +189,29 @@ void hidePreferences()
 	[[Didomi shared] hidePreferences];
 }
 
-bool isConsentRequired()
+int isConsentRequired()
 {
-	return [[Didomi shared] isConsentRequired];
+    return convertBoolToInt([[Didomi shared] isConsentRequired]);
 }
 
-bool isPreferencesVisible()
+int isPreferencesVisible()
 {
-	return [[Didomi shared] isPreferencesVisible];
+    return convertBoolToInt([[Didomi shared] isPreferencesVisible]);
 }
 
-bool isNoticeVisible()
+int isNoticeVisible()
 {
-    return [[Didomi shared] isNoticeVisible];
+    return convertBoolToInt([[Didomi shared] isNoticeVisible]);
 }
 
 void showPreferences()
 {
-	[[Didomi shared] showPreferencesWithController:(UnityGetGLViewController()) view:(ViewsPurposes)];
+    [[Didomi shared] showPreferencesWithController:(UnityGetGLViewController()) view:(ViewsPurposes)];
 }
 
-bool isUserConsentStatusPartial()
+int isUserConsentStatusPartial()
 {
-	return [[Didomi shared] isUserConsentStatusPartial];
+    return convertBoolToInt([[Didomi shared] isUserConsentStatusPartial]);
 }
 
 void reset()
@@ -214,19 +219,19 @@ void reset()
     [[Didomi shared] reset];
 }
 
-bool setUserAgreeToAll()
+int setUserAgreeToAll()
 {
-	return [[Didomi shared] setUserAgreeToAll];
+    return convertBoolToInt([[Didomi shared] setUserAgreeToAll]);
 }
 
-bool setUserDisagreeToAll()
+int setUserDisagreeToAll()
 {
-	return [[Didomi shared] setUserDisagreeToAll];
+    return convertBoolToInt([[Didomi shared] setUserDisagreeToAll]);
 }
 
-bool shouldConsentBeCollected()
+int shouldConsentBeCollected()
 {
-	return [[Didomi shared] shouldConsentBeCollected];
+    return convertBoolToInt([[Didomi shared] shouldConsentBeCollected]);
 }
 
 void showNotice()
@@ -234,46 +239,45 @@ void showNotice()
     [[Didomi shared] showNotice];
 }
 
- char* ConvertSetToJsonText( NSSet<NSString *> * dataSet)
- {
-	NSArray<NSString *> * dataArray= [dataSet allObjects ];
+char* convertSetToJsonText(NSSet<NSString *> * dataSet)
+{
+   NSArray<NSString *> * dataArray= [dataSet allObjects ];
 
-	NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dataArray options:NSJSONWritingPrettyPrinted error:nil];
+   NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dataArray options:NSJSONWritingPrettyPrinted error:nil];
 
-    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+   NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 
-	NSLog(@"jsonData as string:\n%@", jsonString);
+   NSLog(@"jsonData as string:\n%@", jsonString);
 
-	return cStringCopy([jsonString UTF8String]);
- }
-
+   return cStringCopy([jsonString UTF8String]);
+}
 
 char* getDisabledPurposeIds()
 {
     NSSet<NSString *> * dataSet=[[Didomi shared] getDisabledPurposeIds];
-	
-	return ConvertSetToJsonText(dataSet);    
+    
+    return convertSetToJsonText(dataSet);
 }
 
 char* getDisabledVendorIds()
 {
     NSSet<NSString *> * dataSet=[[Didomi shared] getDisabledVendorIds];
-	
-	return ConvertSetToJsonText(dataSet);    
+    
+    return convertSetToJsonText(dataSet);
 }
 
 char* getEnabledPurposeIds()
 {
     NSSet<NSString *> * dataSet=[[Didomi shared] getEnabledPurposeIds];
-	
-	return ConvertSetToJsonText(dataSet);    
+    
+    return convertSetToJsonText(dataSet);
 }
 
 char* getEnabledVendorIds()
 {
     NSSet<NSString *> * dataSet=[[Didomi shared] getEnabledVendorIds];
-	
-	return ConvertSetToJsonText(dataSet);    
+    
+    return convertSetToJsonText(dataSet);
 }
 
 char* getJavaScriptForWebView()
@@ -286,27 +290,27 @@ char* getJavaScriptForWebView()
 char* getRequiredPurposeIds()
 {
     NSSet<NSString *> * dataSet=[[Didomi shared] getRequiredPurposeIds];
-	
-	return ConvertSetToJsonText(dataSet);    
+    
+    return convertSetToJsonText(dataSet);
 }
 
 char* getRequiredVendorIds()
 {
     NSSet<NSString *> * dataSet=[[Didomi shared] getRequiredVendorIds];
-	
-	return ConvertSetToJsonText(dataSet);    
+    
+    return convertSetToJsonText(dataSet);
 }
  
- char* ConvertDictinaryToJsonText( NSDictionary<NSString *, NSString *> * dataDict)
- {
-	NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dataDict options:NSJSONWritingPrettyPrinted error:nil];
-	
+char* convertDictionaryToJsonText( NSDictionary<NSString *, NSString *> * dataDict)
+{
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dataDict options:NSJSONWritingPrettyPrinted error:nil];
+    
     NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 
-	NSLog(@"jsonData dictionary as string:\n%@", jsonString);
+    NSLog(@"jsonData dictionary as string:\n%@", jsonString);
 
-	return cStringCopy([jsonString UTF8String]);
- }
+    return cStringCopy([jsonString UTF8String]);
+}
 
 char* getText(char* key)
 {
@@ -317,7 +321,7 @@ char* getText(char* key)
 		return cStringCopy([@"" UTF8String]);
 	}
 
-	return ConvertDictinaryToJsonText(dataDict);
+    return convertDictionaryToJsonText(dataDict);
 }
 
 NSSet<NSString *> * ConvertJsonToSet(char* jsonText)
@@ -333,17 +337,18 @@ NSSet<NSString *> * ConvertJsonToSet(char* jsonText)
 	return retval;
  }
 
-bool setUserConsentStatus(char* enabledPurposeIds, char* disabledPurposeIds, char* enabledVendorIds, char* disabledVendorIds)
+int setUserConsentStatus(char* enabledPurposeIds, char* disabledPurposeIds, char* enabledVendorIds, char* disabledVendorIds)
 {
 	NSSet<NSString *> * enabledPurposeIdsSet=ConvertJsonToSet(enabledPurposeIds);
 	NSSet<NSString *> * disabledPurposeIdsSet=ConvertJsonToSet(disabledPurposeIds);
 	NSSet<NSString *> * enabledVendorIdsSet=ConvertJsonToSet(enabledVendorIds);
 	NSSet<NSString *> * disabledVendorIdsSet=ConvertJsonToSet(disabledVendorIds);
 
-    return [[Didomi shared] setUserConsentStatusWithEnabledPurposeIds:enabledPurposeIdsSet disabledPurposeIds:disabledPurposeIdsSet enabledVendorIds:enabledVendorIdsSet disabledVendorIds:disabledVendorIdsSet];
+    bool result = [[Didomi shared] setUserConsentStatusWithEnabledPurposeIds:enabledPurposeIdsSet disabledPurposeIds:disabledPurposeIdsSet enabledVendorIds:enabledVendorIdsSet disabledVendorIds:disabledVendorIdsSet];
+    return convertBoolToInt(result);
 }
 
-bool setUserStatus(char* enabledConsentPurposeIds, char* disabledConsentPurposeIds, char* enabledLIPurposeIds, char* disabledLIPurposeIds, char* enabledConsentVendorIds, char* disabledConsentVendorIds, char* enabledLIVendorIds, char* disabledLIVendorIds)
+int setUserStatus(char* enabledConsentPurposeIds, char* disabledConsentPurposeIds, char* enabledLIPurposeIds, char* disabledLIPurposeIds, char* enabledConsentVendorIds, char* disabledConsentVendorIds, char* enabledLIVendorIds, char* disabledLIVendorIds)
 {
 	NSSet<NSString *> * enabledConsentPurposeIdsSet=ConvertJsonToSet(enabledConsentPurposeIds);
 	NSSet<NSString *> * disabledConsentPurposeIdsSet=ConvertJsonToSet(disabledConsentPurposeIds);
@@ -354,12 +359,14 @@ bool setUserStatus(char* enabledConsentPurposeIds, char* disabledConsentPurposeI
 	NSSet<NSString *> * enabledLIVendorIdsSet=ConvertJsonToSet(enabledLIVendorIds);
 	NSSet<NSString *> * disabledLIVendorIdsSet=ConvertJsonToSet(disabledLIVendorIds);
 
-    return [[Didomi shared] setUserStatusWithEnabledConsentPurposeIds:enabledConsentPurposeIdsSet disabledConsentPurposeIds:disabledConsentPurposeIdsSet enabledLIPurposeIds:enabledLIPurposeIdsSet disabledLIPurposeIds:disabledLIPurposeIdsSet enabledConsentVendorIds:enabledConsentVendorIdsSet disabledConsentVendorIds:disabledConsentVendorIdsSet enabledLIVendorIds:enabledLIVendorIdsSet disabledLIVendorIds:disabledLIVendorIdsSet];
+    bool result = [[Didomi shared] setUserStatusWithEnabledConsentPurposeIds:enabledConsentPurposeIdsSet disabledConsentPurposeIds:disabledConsentPurposeIdsSet enabledLIPurposeIds:enabledLIPurposeIdsSet disabledLIPurposeIds:disabledLIPurposeIdsSet enabledConsentVendorIds:enabledConsentVendorIdsSet disabledConsentVendorIds:disabledConsentVendorIdsSet enabledLIVendorIds:enabledLIVendorIdsSet disabledLIVendorIds:disabledLIVendorIdsSet];
+    return convertBoolToInt(result);
 }
 
-bool setUserStatus1(BOOL purposesConsentStatus, BOOL purposesLIStatus, BOOL vendorsConsentStatus, BOOL vendorsLIStatus)
+int setUserStatus1(BOOL purposesConsentStatus, BOOL purposesLIStatus, BOOL vendorsConsentStatus, BOOL vendorsLIStatus)
 {
-    return [[Didomi shared] setUserStatusWithPurposesConsentStatus:purposesConsentStatus purposesLIStatus:purposesLIStatus vendorsConsentStatus:vendorsConsentStatus vendorsLIStatus:vendorsLIStatus];
+    bool result = [[Didomi shared] setUserStatusWithPurposesConsentStatus:purposesConsentStatus purposesLIStatus:purposesLIStatus vendorsConsentStatus:vendorsConsentStatus vendorsLIStatus:vendorsLIStatus];
+    return convertBoolToInt(result);
 }
 
 void setUser(char* organizationUserId)

--- a/source/Assets/Plugins/Didomi/Scripts/IOS/DidomiFramework.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/IOS/DidomiFramework.cs
@@ -26,13 +26,13 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool isReady();
+        private static extern int isReady();
 #endif
 
         public static bool CallIsReadyMethod()
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return isReady();
+            return isReady() == 1;
 #else
             return false;
 #endif
@@ -40,15 +40,13 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool setupUI();
+        private static extern void setupUI();
 #endif
 
-        public static bool SetupUI()
+        public static void SetupUI()
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return setupUI();
-#else
-            return false;
+            setupUI();
 #endif
         }
 
@@ -88,7 +86,7 @@ namespace IO.Didomi.SDK.IOS
             string noticeId);
 #endif
 
-        public static bool Initialize(
+        public static void Initialize(
           string apiKey,
           string localConfigurationPath,
           string remoteConfigurationPath,
@@ -100,8 +98,6 @@ namespace IO.Didomi.SDK.IOS
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
             initializeWithNoticeId(apiKey, localConfigurationPath, remoteConfigurationPath, providerId, disableDidomiRemoteConfig, languageCode, noticeId);
 #endif
-
-            return false;
         }
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
@@ -117,7 +113,7 @@ namespace IO.Didomi.SDK.IOS
         );
 #endif
 
-        public static bool Initialize(DidomiInitializeParameters initializeParameters)
+        public static void Initialize(DidomiInitializeParameters initializeParameters)
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
             initializeWithParameters(
@@ -130,8 +126,6 @@ namespace IO.Didomi.SDK.IOS
                 initializeParameters.noticeId
                 );
 #endif
-
-            return false;
         }
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
@@ -274,13 +268,13 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool isConsentRequired();
+        private static extern int isConsentRequired();
 #endif
 
         public static bool IsConsentRequired()
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return isConsentRequired();
+            return isConsentRequired() == 1;
 #else
             return false;
 #endif
@@ -288,13 +282,13 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool isNoticeVisible();
+        private static extern int isNoticeVisible();
 #endif
 
         public static bool IsNoticeVisible()
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return isNoticeVisible();
+            return isNoticeVisible() == 1;
 #else
             return false;
 #endif
@@ -302,13 +296,13 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool isPreferencesVisible();
+        private static extern int isPreferencesVisible();
 #endif
 
         public static bool IsPreferencesVisible()
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return isPreferencesVisible();
+            return isPreferencesVisible() == 1;
 #else
             return false;
 #endif
@@ -329,13 +323,13 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool isUserConsentStatusPartial();
+        private static extern int isUserConsentStatusPartial();
 #endif
 
         public static bool IsUserConsentStatusPartial()
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return isUserConsentStatusPartial();
+            return isUserConsentStatusPartial() == 1;
 #else
             return false;
 #endif
@@ -355,13 +349,13 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool setUserAgreeToAll();
+        private static extern int setUserAgreeToAll();
 #endif
 
         public static bool SetUserAgreeToAll()
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return setUserAgreeToAll();
+            return setUserAgreeToAll() == 1;
 #else
             return false;
 #endif
@@ -369,13 +363,13 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool setUserDisagreeToAll();
+        private static extern int setUserDisagreeToAll();
 #endif
 
         public static bool SetUserDisagreeToAll()
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return setUserDisagreeToAll();
+            return setUserDisagreeToAll() == 1;
 #else
             return false;
 #endif
@@ -383,13 +377,13 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool shouldConsentBeCollected();
+        private static extern int shouldConsentBeCollected();
 #endif
 
         public static bool ShouldConsentBeCollected()
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return shouldConsentBeCollected();
+            return shouldConsentBeCollected() == 1;
 #else
             return false;
 #endif
@@ -730,13 +724,14 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool setUserConsentStatus(string enabledPurposeIds, string disabledPurposeIds, string enabledVendorIds, string disabledVendorIds);
+        private static extern int setUserConsentStatus(string enabledPurposeIds, string disabledPurposeIds, string enabledVendorIds, string disabledVendorIds);
 #endif
 
         public static bool SetUserConsentStatus(string enabledPurposeIds, string disabledPurposeIds, string enabledVendorIds, string disabledVendorIds)
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return setUserConsentStatus(enabledPurposeIds, disabledPurposeIds, enabledVendorIds, disabledVendorIds);
+            var result = setUserConsentStatus(enabledPurposeIds, disabledPurposeIds, enabledVendorIds, disabledVendorIds);
+            return result == 1;
 #else
             return false;
 #endif
@@ -744,7 +739,7 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool setUserStatus(string enabledConsentPurposeIds,
+        private static extern int setUserStatus(string enabledConsentPurposeIds,
             string disabledConsentPurposeIds,
             string enabledLIPurposeIds,
             string disabledLIPurposeIds,
@@ -765,7 +760,7 @@ namespace IO.Didomi.SDK.IOS
             string disabledLIVendorIds)
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return setUserStatus(
+            var result = setUserStatus(
                 enabledConsentPurposeIds,
                 disabledConsentPurposeIds,
                 enabledLIPurposeIds,
@@ -774,6 +769,7 @@ namespace IO.Didomi.SDK.IOS
                 disabledConsentVendorIds,
                 enabledLIVendorIds,
                 disabledLIVendorIds);
+            return result == 1;
 #else
             return false;
 #endif
@@ -782,13 +778,14 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern bool setUserStatus1(bool purposesConsentStatus, bool purposesLIStatus, bool vendorsConsentStatus, bool vendorsLIStatus);
+        private static extern int setUserStatus1(bool purposesConsentStatus, bool purposesLIStatus, bool vendorsConsentStatus, bool vendorsLIStatus);
 #endif
 
         public static bool SetUserStatus(bool purposesConsentStatus, bool purposesLIStatus, bool vendorsConsentStatus, bool vendorsLIStatus)
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            return setUserStatus1(purposesConsentStatus, purposesLIStatus, vendorsConsentStatus, vendorsLIStatus);
+            var result = setUserStatus1(purposesConsentStatus, purposesLIStatus, vendorsConsentStatus, vendorsLIStatus);
+            return result == 1;
 #else
             return false;
 #endif


### PR DESCRIPTION
In some cases, returning `bool` from objective-C to C# gave a wrong result. To avoid this, we pass `int` instead with 1 = `True`, 0 = `False`