### PR TITLE
Fix iOS UI test in recent Unity versions

### DIFF
--- a/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs
@@ -63,6 +63,12 @@ public class UITestsSuite: DidomiBaseTests
         // On IOS, ShowNotice() requires a previous call to SetupUI()
         yield return SetupUIWithoutNotice();
 
+        // In recent Unity versions, an error message is triggered on iOS
+        if (Application.platform == RuntimePlatform.IPhonePlayer
+            && string.Compare(Application.unityVersion, "2021.3.20f1") > 0)
+        {
+            LogAssert.ignoreFailingMessages = true;
+        }
         Didomi.GetInstance().ShowNotice();
         yield return new WaitForSeconds(1);
         Assert.True(Didomi.GetInstance().IsNoticeVisible(), "Notice should be visible");
@@ -124,12 +130,11 @@ public class UITestsSuite: DidomiBaseTests
 
     private IEnumerator SetupUIWithoutNotice()
     {
+        Didomi.GetInstance().SetUserAgreeToAll();
         Didomi.GetInstance().SetupUI();
         yield return new WaitForSeconds(1);
-        Didomi.GetInstance().HideNotice();
-        yield return new WaitForSeconds(1);
         Assert.False(Didomi.GetInstance().IsNoticeVisible(), "Notice should not be visible at startup");
-        ResetEvents();
+        Didomi.GetInstance().Reset();
     }
 
     /**

--- a/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs
@@ -63,13 +63,19 @@ public class UITestsSuite: DidomiBaseTests
         // On IOS, ShowNotice() requires a previous call to SetupUI()
         yield return SetupUIWithoutNotice();
 
-        // In recent Unity versions, an error message is triggered on iOS
-        if (Application.platform == RuntimePlatform.IPhonePlayer
-            && string.Compare(Application.unityVersion, "2021.3.20f1") > 0)
+        // In recent Unity versions, an error message is triggered on iOS, we need to ignore it:
+        // '[Error] An abnormal situation has occurred: the PlayerLoop internal function has been called recursively. Please contact Customer Support with a sample project so that we can reproduce the problem and troubleshoot it.'
+        bool skipErrorMessage = Application.platform == RuntimePlatform.IPhonePlayer
+            && string.Compare(Application.unityVersion, "2021.3.20f1") > 0;
+        if (skipErrorMessage)
         {
             LogAssert.ignoreFailingMessages = true;
         }
         Didomi.GetInstance().ShowNotice();
+        if (skipErrorMessage)
+        {
+            LogAssert.ignoreFailingMessages = false;
+        }
         yield return new WaitForSeconds(1);
         Assert.True(Didomi.GetInstance().IsNoticeVisible(), "Notice should be visible");
         AssertEvents("Called ShowNotice", expectNoticeDisplayed: true);

--- a/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs
@@ -63,7 +63,7 @@ public class UITestsSuite: DidomiBaseTests
         // On IOS, ShowNotice() requires a previous call to SetupUI()
         yield return SetupUIWithoutNotice();
 
-        // In recent Unity versions, an error message is triggered on iOS, we need to ignore it:
+        // In Unity versions after 2021.3.20f1, an error message is triggered on iOS, we need to ignore it:
         // '[Error] An abnormal situation has occurred: the PlayerLoop internal function has been called recursively. Please contact Customer Support with a sample project so that we can reproduce the problem and troubleshoot it.'
         bool skipErrorMessage = Application.platform == RuntimePlatform.IPhonePlayer
             && string.Compare(Application.unityVersion, "2021.3.20f1") > 0;


### PR DESCRIPTION
Prevent iOS test from failing because of an unexpected error message (only affects tests)