### PR TITLE
Fix iOS tests failing in bash mode

### DIFF
--- a/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorTestsSuite.cs
@@ -28,7 +28,7 @@ public class PurposeAndVendorTestsSuite: DidomiBaseTests
         }
         else
         {
-            Assert.Inconclusive("Test only valid for Android platform");
+            Assert.Pass("Test only valid for Android platform");
         }
     }
 
@@ -46,7 +46,7 @@ public class PurposeAndVendorTestsSuite: DidomiBaseTests
         }
         else
         {
-            Assert.Inconclusive("Test only valid for Android platform");
+            Assert.Pass("Test only valid for Android platform");
         }
     }
 

--- a/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/PurposeAndVendorTestsSuite.cs
@@ -28,7 +28,7 @@ public class PurposeAndVendorTestsSuite: DidomiBaseTests
         }
         else
         {
-            Assert.Pass("Test only valid for Android platform");
+            Assert.Pass("Test only valid for Android platform: method not supported on iOS");
         }
     }
 
@@ -46,7 +46,7 @@ public class PurposeAndVendorTestsSuite: DidomiBaseTests
         }
         else
         {
-            Assert.Pass("Test only valid for Android platform");
+            Assert.Pass("Test only valid for Android platform: method not supported on iOS");
         }
     }
 

--- a/source/scripts/runAndroidTests.sh
+++ b/source/scripts/runAndroidTests.sh
@@ -16,10 +16,11 @@ LOG_PATH="artifacts/androidTestsRun.log"
 # Run the tests
 $UNITY_PATH -batchmode -buildTarget Android -runTests -testResults $RESULTS_PATH -testPlatform Android -logFile $LOG_PATH
 
-if [ $? -eq 0 ]
+result=$?
+if [ $result -eq 0 ]
 then
     echo "Android tests passed!"
 else
-    echo "Android tests failed!"
+    echo "Android tests failed with exit code $result"
     exit 1
 fi

--- a/source/scripts/runIOSTests.sh
+++ b/source/scripts/runIOSTests.sh
@@ -13,11 +13,11 @@ LOG_PATH="artifacts/iosTestsRun.log"
 
 # Run the tests
 $UNITY_PATH -batchmode -buildTarget iOS -runTests -testResults $RESULTS_PATH -testPlatform iOS -logFile $LOG_PATH
-
- if [ $? -eq 0 ]
+result=$?
+if [ $result -eq 0 ]
 then
     echo "iOS tests passed!"
 else
-    echo "iOS tests failed!"
+    echo "iOS tests failed with exit code $result"
     exit 1
 fi


### PR DESCRIPTION
Use Assert.Pass() instead of Assert.Inconclusive() for iOS Vendors and Purposes tests, so test script is marked as Success