### PR TITLE
check for device before launching android tests

### DIFF
--- a/source/scripts/runAndroidTests.sh
+++ b/source/scripts/runAndroidTests.sh
@@ -48,7 +48,7 @@ if [ -z "$connected_devices" ]; then
     # Kill the emulator from the background
     adb -s emulator-5554 emu kill
     # Wait for the emulator to close
-    until [ -z "$(adb devices | grep "emulator")" ]; do
+    while adb devices | grep -q "emulator"; do
         echo "Waiting for $DEVICE to close..."
         sleep 1
     done

--- a/source/scripts/runAndroidTests.sh
+++ b/source/scripts/runAndroidTests.sh
@@ -13,21 +13,17 @@ UNITY_PATH=$(awk -F= '/^editor/ {print $2}' $scriptsDir/unity.properties)
 RESULTS_PATH="artifacts/android-test-results.xml"
 LOG_PATH="artifacts/androidTestsRun.log"
 
-# Set the path to adb and emulator
-ADB=~/Library/Android/sdk/platform-tools/adb
-EMULATOR=~/Library/Android/sdk/emulator/emulator
-
 # Check for any Android emulator / device
-connected_devices=$("$ADB" devices | grep -v "List" | grep "device$")
+connected_devices=$(adb devices | grep -v "List" | grep "device$")
 if [ -z "$connected_devices" ]; then
     echo "No Android device connected."
     
     # Search for device name
-    DEVICE=$("$EMULATOR" -list-avds | head -n 1)
+    DEVICE=$(emulator -list-avds | head -n 1)
 
     # Start the emulator in the background
     echo "Launching $DEVICE, please wait a few seconds..."
-    "$EMULATOR" -avd "$DEVICE" -no-window &
+    emulator -avd "$DEVICE" -no-window &
 
     # Wait for the emulator to be detected
     adb wait-for-device
@@ -50,9 +46,9 @@ $UNITY_PATH -batchmode -buildTarget Android -runTests -testResults $RESULTS_PATH
 
 if [ -z "$connected_devices" ]; then
     # Kill the emulator from the background
-    "$ADB" -s emulator-5554 emu kill
+    adb -s emulator-5554 emu kill
     # Wait for the emulator to close
-    until [ -z "$("$ADB" devices | grep "emulator")" ]; do
+    until [ -z "$(adb devices | grep "emulator")" ]; do
         echo "Waiting for $DEVICE to close..."
         sleep 1
     done

--- a/source/scripts/runAndroidTests.sh
+++ b/source/scripts/runAndroidTests.sh
@@ -13,6 +13,33 @@ UNITY_PATH=$(awk -F= '/^editor/ {print $2}' $scriptsDir/unity.properties)
 RESULTS_PATH="artifacts/android-test-results.xml"
 LOG_PATH="artifacts/androidTestsRun.log"
 
+# Check for any Android emulator / device
+connected_devices=$(adb devices | grep -v "List" | grep "device$")
+if [ -z "$connected_devices" ]; then
+    echo "No Android device connected."
+    
+    # Search for device name
+    DEVICE=$(emulator -list-avds | head -n 1)
+
+    echo "Launching $DEVICE, please wait a few seconds..."
+    ~/Library/Android/sdk/emulator/emulator "@$DEVICE" &
+
+    # Wait for the Android device to be detected
+    adb wait-for-device
+
+    echo "Device detected. Waiting for device to fully boot..."
+
+    # Wait until the boot animation completes
+    until adb shell getprop sys.boot_completed | grep -m 1 '1'; do
+        echo "Waiting for $DEVICE to complete booting..."
+        sleep 1
+    done
+
+    echo "$DEVICE is ready."
+else
+    echo "Android device(s) connected, continue with tests."
+fi
+
 # Run the tests
 $UNITY_PATH -batchmode -buildTarget Android -runTests -testResults $RESULTS_PATH -testPlatform Android -logFile $LOG_PATH
 


### PR DESCRIPTION
check for device before launching android tests
- If a connected device is found, continue the tests
- If no connected device found, we launch an emulator and wait for it before continuing the tests