### PR TITLE
Reset iOS SDK before sync tests

### DIFF
--- a/source/Assets/Plugins/Didomi/IOS/Didomi.mm
+++ b/source/Assets/Plugins/Didomi/IOS/Didomi.mm
@@ -1045,4 +1045,9 @@ void removeVendorStatusListener( char* vendorId)
     [[Didomi shared] removeVendorStatusListenerWithId: CreateNSString(vendorId)];
 }
 
+void resetDidomi()
+{
+    Didomi.shared = [[Didomi alloc] init];
+}
+
 }

--- a/source/Assets/Plugins/Didomi/Scripts/IOS/DidomiFramework.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/IOS/DidomiFramework.cs
@@ -886,5 +886,20 @@ namespace IO.Didomi.SDK.IOS
             clearUser();
 #endif
         }
+
+#if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
+        [DllImport("__Internal")]
+        private static extern void resetDidomi();
+#endif
+
+        /// <summary>
+        /// For tests only
+        /// </summary>
+        public static void ResetDidomi()
+        {
+#if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
+            resetDidomi();
+#endif
+        }
     }
 }

--- a/source/Assets/Plugins/Didomi/Tests/DidomiBaseTests.cs
+++ b/source/Assets/Plugins/Didomi/Tests/DidomiBaseTests.cs
@@ -45,7 +45,7 @@ public abstract class DidomiBaseTests
         }
 
         // Make sure instance from previous test is not present
-        yield return new WaitForSeconds(1);
+        yield return new WaitForSeconds(0.5f);
 
         didomi.OnReady(
             () =>

--- a/source/Assets/Plugins/Didomi/Tests/SyncUserAfterInitTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/SyncUserAfterInitTestsSuite.cs
@@ -5,7 +5,7 @@ using IO.Didomi.SDK;
 using System.Collections.Generic;
 
 /// <summary>
-/// Tests related to sharing consent with Webview / Web SDK
+/// Tests related to user status synchronization between platforms after SDK was initialized
 /// </summary>
 public class SyncUserAfterInitTestsSuite : SyncUserBaseTests
 {
@@ -26,12 +26,9 @@ public class SyncUserAfterInitTestsSuite : SyncUserBaseTests
     [UnitySetUp]
     public IEnumerator Setup()
     {
-        if (!Didomi.GetInstance().IsReady())
-        {
-            yield return LoadSdk();
-        }
-        Didomi.GetInstance().ClearUser();
-        Didomi.GetInstance().Reset();
+        yield return LoadSdk();
+        ResetStatus();
+        ResetResults();
     }
 
     [TearDown]

--- a/source/Assets/Plugins/Didomi/Tests/SyncUserBaseTests.cs
+++ b/source/Assets/Plugins/Didomi/Tests/SyncUserBaseTests.cs
@@ -6,7 +6,7 @@ using IO.Didomi.SDK.Events;
 using System;
 
 /// <summary>
-/// Base for tests related to sharing consent with Webview / Web SDK
+/// Base for tests related to user status synchronization between platforms
 /// </summary>
 public abstract class SyncUserBaseTests : DidomiBaseTests
 {
@@ -22,6 +22,11 @@ public abstract class SyncUserBaseTests : DidomiBaseTests
 
     protected void SetUpSuite()
     {
+#if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
+        // For iOS, we need to fully reset the SDK between each test suite
+        IO.Didomi.SDK.IOS.DidomiFramework.ResetDidomi();
+#endif
+
         eventListener.SyncDone += EventListener_SyncDone;
         eventListener.SyncReady += EventListener_SyncReady;
         eventListener.SyncError += EventListener_SyncError;
@@ -30,8 +35,8 @@ public abstract class SyncUserBaseTests : DidomiBaseTests
 
     protected void TearDown()
     {
-        ResetResults();
         ResetStatus();
+        ResetResults();
     }
 
     protected void TearDownSuite()

--- a/source/Assets/Plugins/Didomi/Tests/SyncUserBeforeInitTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/SyncUserBeforeInitTestsSuite.cs
@@ -4,7 +4,7 @@ using UnityEngine.TestTools;
 using IO.Didomi.SDK;
 
 /// <summary>
-/// Tests related to sharing consent with Webview / Web SDK set before SDK is initialized
+/// Tests related to user status synchronization between platforms before SDK was initialized
 /// </summary>
 public class SyncUserBeforeInitTestsSuite : SyncUserBaseTests
 {
@@ -12,6 +12,16 @@ public class SyncUserBeforeInitTestsSuite : SyncUserBaseTests
     public new void SetUpSuite()
     {
         base.SetUpSuite();
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        if (Didomi.GetInstance().IsReady())
+        {
+            ResetStatus();
+            ResetResults();
+        }
     }
 
     [TearDown]
@@ -31,6 +41,6 @@ public class SyncUserBeforeInitTestsSuite : SyncUserBaseTests
     {
         Didomi.GetInstance().SetUser(testUserId);
         yield return LoadSdk();
-        yield return ExpectSyncSuccess("Set user before initialization", true, false);
+        yield return ExpectSyncSuccess("Set user before initialization", true, true);
     }
 }


### PR DESCRIPTION
Reset iOS SDK before sync tests, to start from a clean state