### PR TITLE
Fix: build fails on linux because of wrong dir separator

### DIFF
--- a/source/Assets/Plugins/Didomi/Editor/PostProcessor.cs
+++ b/source/Assets/Plugins/Didomi/Editor/PostProcessor.cs
@@ -295,18 +295,7 @@ public static class PostProcessorSettings
     /// </summary>
     public static void InitSettings()
     {
-        bool isWinEditor = Application.platform == RuntimePlatform.WindowsEditor;
-        bool isOSXEditor = Application.platform == RuntimePlatform.OSXEditor;
-
-        if (isOSXEditor)
-        {
-            FilePathSeperator = "/";
-        }
-        else
-        {
-            FilePathSeperator = @"\";
-        }
-
+        FilePathSeperator = Path.DirectorySeparatorChar.ToString();
         DidomiConfigPath = Application.dataPath + $@"{FilePathSeperator}DidomiConfig";
     }
 


### PR DESCRIPTION
Hi. We have a build failing on Linux build agents due to wrong directory separtor. Here's the fix.

PR contains some whitespace changes, if you don't mind

Example of exception

```
[18:44:41]E:				 [BuildPipeline.BuildPlayer()] [EXCEPTION] FileNotFoundException: Could not find file "Code/Library/Bee/Android/Prj/IL2CPP/Gradle/unityLibrary/src\main\java\com\unity3d\player\UnityPlayerActivity.java"
[18:44:41] :				 [BuildPipeline.BuildPlayer()] FileNotFoundException: Could not find file "Code/Library/Bee/Android/Prj/IL2CPP/Gradle/unityLibrary/src\main\java\com\unity3d\player\UnityPlayerActivity.java"
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x0019e] in <6b6c247d47d645b790f8ec1a6fff97f8>:0
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.IO.FileOptions options) [0x00000] in <6b6c247d47d645b790f8ec1a6fff97f8>:0
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at (wrapper remoting-invoke-with-check) System.IO.FileStream..ctor(string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,int,System.IO.FileOptions)
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks, System.Int32 bufferSize) [0x00055] in <6b6c247d47d645b790f8ec1a6fff97f8>:0
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks) [0x00000] in <6b6c247d47d645b790f8ec1a6fff97f8>:0
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at (wrapper remoting-invoke-with-check) System.IO.StreamReader..ctor(string,System.Text.Encoding,bool)
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at System.IO.File.InternalReadAllText (System.String path, System.Text.Encoding encoding) [0x00000] in <6b6c247d47d645b790f8ec1a6fff97f8>:0
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at System.IO.File.ReadAllText (System.String path) [0x0002c] in <6b6c247d47d645b790f8ec1a6fff97f8>:0
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at PostProcessor.ReplaceLineInFile (System.String path, System.String oldValue, System.String newValue) [0x00000] in Code/Library/PackageCache/games.my.mrgs.didomi@6.14.3/Editor/PostProcessor.cs:82
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at DidomiPostProcessorGradleAndroidProject.UpdateUnityPlayerActivity (System.String path) [0x000a0] in Code/Library/PackageCache/games.my.mrgs.didomi@6.14.3/Editor/PostProcessor.cs:62
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at DidomiPostProcessorGradleAndroidProject.AndroidPostProcess (System.String path) [0x00000] in Code/Library/PackageCache/games.my.mrgs.didomi@6.14.3/Editor/PostProcessor.cs:27
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at DidomiPostProcessorGradleAndroidProject.OnPostGenerateGradleAndroidProject (System.String path) [0x00015] in Code/Library/PackageCache/games.my.mrgs.didomi@6.14.3/Editor/PostProcessor.cs:18
[18:44:41] :				 [BuildPipeline.BuildPlayer()] at UnityEditor.Android.AndroidBuildPipelineInterfaces.OnGeneratePlatformProjectPostprocess (System.String path, System.Boolean strict) [0x00026] in /home/bokken/build/output/unity/unity/Editor/Mono/BuildPipeline/Android/AndroidPostGenerateGradleProject.cs:39
```