### PR TITLE
CMP-4994 - Rename `IDPL` regulation into `ICDPA`

### DIFF
--- a/source/Assets/Plugins/Didomi/Scripts/IOS/DDMRegulation.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/IOS/DDMRegulation.cs
@@ -13,7 +13,7 @@ namespace Assets.Plugins.Scripts.IOS
         ctdpa = 4,
         dpdpa = 5,
         fdbr = 6,
-        idpl = 7,
+        icdpa = 7,
         mcdpa = 8,
         nhpa = 9,
         njdpa = 10,


### PR DESCRIPTION
Rename `IDPL` regulation into `ICDPA`

⚠️ Native iOS SDK need to be update prior to this change