### PR TITLE
Add support for showPreferences view parameter

### DIFF
--- a/source/Assets/Plugins/Didomi/IOS/Didomi.mm
+++ b/source/Assets/Plugins/Didomi/IOS/Didomi.mm
@@ -368,9 +368,9 @@ int isNoticeVisible()
     return convertBoolToInt([[Didomi shared] isNoticeVisible]);
 }
 
-void showPreferences()
+void showPreferences(int intView)
 {
-    [[Didomi shared] showPreferencesWithController:(UnityGetGLViewController()) view:(ViewsPurposes)];
+    [[Didomi shared] showPreferencesWithController:(UnityGetGLViewController()) view:(Views)intView];
 }
 
 int isUserConsentStatusPartial()

--- a/source/Assets/Plugins/Didomi/Scripts/Android/AndroidDidomi.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/Android/AndroidDidomi.cs
@@ -252,9 +252,45 @@ namespace IO.Didomi.SDK.Android
             CallVoidMethodWithActivityArg("showNotice");
         }
 
-        public void ShowPreferences()
+        public void ShowPreferences(Didomi.Views view)
         {
-            CallVoidMethodWithActivityArg("showPreferences");
+            try
+            {
+                using (var playerClass = new AndroidJavaClass(UnityPlayerFullClassName))
+                {
+                    using (var activity = playerClass.GetStatic<AndroidJavaObject>("currentActivity"))
+                    {
+                        using (var _pluginClass = new AndroidJavaClass(PluginName))
+                        {
+                            string viewParam;
+
+                            if (view == Didomi.Views.Vendors)
+                            {
+                                viewParam = _pluginClass.GetStatic<string>("VIEW_VENDORS");
+                            }
+                            else
+                            {
+                                viewParam = _pluginClass.GetStatic<string>("VIEW_PURPOSES");
+                            }
+
+                            var pluginInstance = _pluginClass.CallStatic<AndroidJavaObject>("getInstance");
+
+                            var obj = new object[2];
+
+                            obj[0] = activity;
+                            obj[1] = viewParam;
+
+                            pluginInstance.Call("showPreferences", obj);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.Log(string.Format("Exception:{0}", ex.ToString()));
+
+                throw ex;
+            }
         }
 
         public void Reset()

--- a/source/Assets/Plugins/Didomi/Scripts/Didomi.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/Didomi.cs
@@ -17,6 +17,16 @@ namespace IO.Didomi.SDK
     /// </summary>
     public class Didomi
     {
+        /// <summary>
+        /// Possible views to open in Preferences screen
+        /// </summary>
+        public enum Views
+        {
+            Purposes = 0,
+            // Mapping to Objective-C: Value 1 is SPI (deprecated)
+            Vendors = 2
+        }
+
         private static Didomi didomiInstance;
         private static readonly object instanceLock = new object();
         private static IDidomi didomiForPlatform = null;
@@ -454,9 +464,10 @@ namespace IO.Didomi.SDK
         /// <summary>
         /// Show the preferences popup for purposes
         /// </summary>
-        public void ShowPreferences()
+        /// <param name="view">Optional: Specify which view to open</param>
+        public void ShowPreferences(Views view = Views.Purposes)
         {
-            didomiForPlatform.ShowPreferences();
+            didomiForPlatform.ShowPreferences(view);
         }
 
         /// <summary>

--- a/source/Assets/Plugins/Didomi/Scripts/IOS/DidomiFramework.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/IOS/DidomiFramework.cs
@@ -246,13 +246,13 @@ namespace IO.Didomi.SDK.IOS
 
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern void showPreferences();
+        private static extern void showPreferences(int intView);
 #endif
 
-        public static void ShowPreferences()
+        public static void ShowPreferences(Didomi.Views view)
         {
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            showPreferences();
+            showPreferences((int)view);
 #endif
         }
 

--- a/source/Assets/Plugins/Didomi/Scripts/IOS/IOSDidomi.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/IOS/IOSDidomi.cs
@@ -192,9 +192,9 @@ namespace IO.Didomi.SDK.IOS
             DidomiFramework.SetupUI();
         }
 
-        public void ShowPreferences()
+        public void ShowPreferences(Didomi.Views view)
         {
-             DidomiFramework.ShowPreferences();
+             DidomiFramework.ShowPreferences(view);
         }
 
         public bool IsUserConsentStatusPartial()

--- a/source/Assets/Plugins/Didomi/Scripts/Interfaces/IDidomi.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/Interfaces/IDidomi.cs
@@ -47,7 +47,7 @@ namespace IO.Didomi.SDK.Interfaces
         void OnReady(Action didomiCallable);
         void SetupUI();
         void ShowNotice();
-        void ShowPreferences();
+        void ShowPreferences(Didomi.Views view);
         void Reset();
         bool SetUserAgreeToAll();
         bool SetUserDisagreeToAll();

--- a/source/Assets/Plugins/Didomi/Scripts/UnityEditor/UnityEditorDidomi.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/UnityEditor/UnityEditorDidomi.cs
@@ -190,7 +190,7 @@ namespace IO.Didomi.SDK.UnityEditor
             ShowNoticeMockUI();
         }
 
-        public void ShowPreferences()
+        public void ShowPreferences(Didomi.Views view)
         {
             if (_disableMockUI)
             {

--- a/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/UITestsSuite.cs
@@ -116,6 +116,24 @@ public class UITestsSuite: DidomiBaseTests
         AssertEvents("Called HidePreferences", expectPreferencesHidden: true);
     }
 
+    [UnityTest]
+    public IEnumerator TestPreferencesVendorsVisibility()
+    {
+        Didomi.GetInstance().ShowPreferences(Didomi.Views.Vendors);
+        yield return new WaitForSeconds(1);
+        Assert.False(Didomi.GetInstance().IsNoticeVisible(), "Notice should not be visible");
+        Assert.True(Didomi.GetInstance().IsPreferencesVisible(), "Preferences screen should be visible");
+        AssertEvents("Called ShowPreferences", expectPreferencesDisplayed: true);
+
+        ResetEvents();
+
+        Didomi.GetInstance().HidePreferences();
+        yield return new WaitForSeconds(2); // Allow longer time to hide both Vendors and Preferences screens
+        Assert.False(Didomi.GetInstance().IsNoticeVisible(), "Notice should still not be visible");
+        Assert.False(Didomi.GetInstance().IsPreferencesVisible(), "Preferences screen should not be visible anymore");
+        AssertEvents("Called HidePreferences", expectPreferencesHidden: true);
+    }
+
     private void EventListener_ShowNotice(object sender, ShowNoticeEvent e)
     {
         noticeDisplayedEvent = true;


### PR DESCRIPTION
Support `showPreferences` `view` parameter to open specific native view. `Purposes` stays the default.