### PR TITLE
Fix a compilation error in Android

### DIFF
--- a/source/Assets/Plugins/Didomi/Editor/PackageJsonUtils.cs
+++ b/source/Assets/Plugins/Didomi/Editor/PackageJsonUtils.cs
@@ -23,5 +23,7 @@ public class PackageJson
     public string version { get; set; }
     public string iosNativeVersion { get; set; }
     public string androidNativeVersion { get; set; }
+    // Should be the same version of AndroidX AppCompat as the one used in the Didomi Android SDK.
+    public string androidxAppCompatVersion { get; set; }
     public string description { get; set; }
 }

--- a/source/Assets/Plugins/Didomi/Editor/PostProcessor.cs
+++ b/source/Assets/Plugins/Didomi/Editor/PostProcessor.cs
@@ -84,9 +84,10 @@ class PostProcessorGradleAndroidProject : IPostGenerateGradleAndroidProject
         var unityPlayerFile = $@"build.gradle";
         var unityPlayerFileAbsolutePath = Path.Combine(path, unityPlayerFile);
         var androidSdkVersion = PackageJsonUtils.Read().androidNativeVersion;
+        var androidxAppCompatVersion = PackageJsonUtils.Read().androidxAppCompatVersion;
         var hasAppCompatDependency = File.ReadAllText(unityPlayerFileAbsolutePath).Contains("androidx.appcompat:appcompat:");
         var appCompatDependencyStr = hasAppCompatDependency ? "" : $@"
-        implementation(""androidx.appcompat:appcompat:1.6.1"")  // Same version as Didomi SDK
+        implementation(""androidx.appcompat:appcompat:{androidxAppCompatVersion}"")  // Same version as Didomi SDK
     ";
         var oldValue = "dependencies {";
         var newValue = $@"dependencies {{

--- a/source/Assets/Plugins/Didomi/Editor/PostProcessor.cs
+++ b/source/Assets/Plugins/Didomi/Editor/PostProcessor.cs
@@ -84,9 +84,13 @@ class PostProcessorGradleAndroidProject : IPostGenerateGradleAndroidProject
         var unityPlayerFile = $@"build.gradle";
         var unityPlayerFileAbsolutePath = Path.Combine(path, unityPlayerFile);
         var androidSdkVersion = PackageJsonUtils.Read().androidNativeVersion;
+        var hasAppCompatDependency = File.ReadAllText(unityPlayerFileAbsolutePath).Contains("androidx.appcompat:appcompat:");
+        var appCompatDependencyStr = hasAppCompatDependency ? "" : $@"
+        implementation(""androidx.appcompat:appcompat:1.6.1"")  // Same version as Didomi SDK
+    ";
         var oldValue = "dependencies {";
         var newValue = $@"dependencies {{
-    implementation(""io.didomi.sdk:android:{androidSdkVersion}"")
+        implementation(""io.didomi.sdk:android:{androidSdkVersion}""){appCompatDependencyStr}
     ";
         PostProcessor.ReplaceLineInFile(unityPlayerFileAbsolutePath, oldValue, newValue);
     }

--- a/source/Assets/Plugins/Didomi/Resources/package.json
+++ b/source/Assets/Plugins/Didomi/Resources/package.json
@@ -5,5 +5,6 @@
 	"version": "2.13.0",
 	"iosNativeVersion": "2.29.1",
 	"androidNativeVersion": "2.29.0",
+	"androidxAppCompatVersion": "1.6.1",
 	"description": "Unity plugin helps you to use native Didomi functionality on Android and iOS."
 }


### PR DESCRIPTION
In my local project, Android compilation was failing with several errors such as

```
/Users/philemonmerlet/didomi-dev/unity/unity-repo/source/Library/Bee/Android/Prj/IL2CPP/Gradle/unityLibrary/src/main/java/com/unity3d/player/UnityPlayerActivity.java:13: error: package androidx.fragment.app does not exist
import androidx.fragment.app.FragmentActivity;
```

It seems the AppCompat dependecy was no longer obtained from the Didomi SDK. This change fixes the issue.