### PR TITLE
Do not mark android tests as passed if they failed + update Unity version used in script

### DIFF
--- a/source/scripts/runAndroidTests.sh
+++ b/source/scripts/runAndroidTests.sh
@@ -43,6 +43,7 @@ fi
 
 # Run the tests
 $UNITY_PATH -batchmode -buildTarget Android -runTests -testResults $RESULTS_PATH -testPlatform Android -logFile $LOG_PATH
+result=$?
 
 if [ -z "$connected_devices" ]; then
     # Kill the emulator from the background
@@ -54,7 +55,6 @@ if [ -z "$connected_devices" ]; then
     done
 fi
 
-result=$?
 if [ $result -eq 0 ]
 then
     echo "Android tests passed!"

--- a/source/scripts/unity.properties
+++ b/source/scripts/unity.properties
@@ -1,1 +1,1 @@
-editor=/Applications/Unity/Hub/Editor/2021.3.20f1/Unity.app/Contents/MacOS/Unity
+editor=/Applications/Unity/Hub/Editor/6000.2.1f1/Unity.app/Contents/MacOS/Unity


### PR DESCRIPTION
- Prevent tests marked as Passed when they actually failed
- Update default `unity.properties` to use Unity 6 for tests and release