### PR TITLE
Restore test for SyncAcknowledged field

### DIFF
--- a/source/Assets/Plugins/Didomi/Tests/AAABeforeSDKInitTestsSuite.cs
+++ b/source/Assets/Plugins/Didomi/Tests/AAABeforeSDKInitTestsSuite.cs
@@ -39,6 +39,13 @@ public class AAABeforeSDKInitTestsSuite : SyncUserBaseTests
     [OneTimeTearDown]
     public new void TearDownSuite()
     {
+        // Update synchronized user token to make sure it doesn't expire in a future test
+        if (Didomi.GetInstance().IsReady())
+        {
+            Didomi.GetInstance().SetUser(new DidomiUserParameters(new UserAuthWithoutParams(testUserId)));
+            Didomi.GetInstance().SetUserDisagreeToAll();
+            Didomi.GetInstance().SetUserAgreeToAll();
+        }
         base.TearDownSuite();
     }
 

--- a/source/Assets/Plugins/Didomi/Tests/SyncUserBaseTests.cs
+++ b/source/Assets/Plugins/Didomi/Tests/SyncUserBaseTests.cs
@@ -105,7 +105,7 @@ public abstract class SyncUserBaseTests : DidomiBaseTests
         {
             // Some tests do not require to check all parameters.
             Assert.AreEqual(expectApplied, statusApplied, "Status applied - " + message);
-            // Assert.AreEqual(expectAcknowledged, syncAcknowledged, "Sync acknowledged - " + message); // TODO Find out why this is not accurate with our test user id
+            Assert.AreEqual(expectAcknowledged, syncAcknowledged, "Sync acknowledged - " + message);
             Assert.IsFalse(syncAcknowledged2, "Sync acknowledged should always fail at the 2nd call - " + message);
         }
     }


### PR DESCRIPTION
`SyncReadyEvent.SyncAcknowledged` was failing because the remote status for the user id was expired.
- At each test run, register a random consent change to force remote status update.
- Restore the now succeeding test.