### PR TITLE
feat: add sdkPath and apiPath to DidomiInitializeParameters

### DIFF
--- a/source/Assets/Plugins/Didomi/IOS/Didomi.mm
+++ b/source/Assets/Plugins/Didomi/IOS/Didomi.mm
@@ -304,7 +304,7 @@ void setUserAgent(char* name, char* version)
     [[Didomi shared] setUserAgentWithName: CreateNSString(name) version:CreateNSString(version)];
 }
 
-void initializeWithParameters(char* apiKey, char* localConfigurationPath, char* remoteConfigurationURL, char* providerId, bool disableDidomiRemoteConfig, char* languageCode, char* noticeId, char* countryCode, char* regionCode, bool isUnderage)
+void initializeWithParameters(char* apiKey, char* localConfigurationPath, char* remoteConfigurationURL, char* providerId, bool disableDidomiRemoteConfig, char* languageCode, char* noticeId, char* countryCode, char* regionCode, bool isUnderage, char* sdkPath, char* apiPath)
 {
     DidomiInitializeParameters *parameters = [[DidomiInitializeParameters alloc]
         initWithApiKey: CreateNSString(apiKey)
@@ -317,6 +317,8 @@ void initializeWithParameters(char* apiKey, char* localConfigurationPath, char* 
         countryCode: CreateNSStringNullable(countryCode)
         regionCode: CreateNSStringNullable(regionCode)
         isUnderage: isUnderage
+        sdkPath: CreateNSStringNullable(sdkPath)
+        apiPath: CreateNSStringNullable(apiPath)
     ];
     [[Didomi shared] initialize: parameters];
 }

--- a/source/Assets/Plugins/Didomi/Resources/package.json
+++ b/source/Assets/Plugins/Didomi/Resources/package.json
@@ -3,8 +3,8 @@
 	"displayName": "Native Didomi",
 	"agentName": "Didomi Unity SDK",
 	"version": "2.26.0",
-	"iosNativeVersion": "2.44.0",
-	"androidNativeVersion": "2.44.0",
+	"iosNativeVersion": "2.45.0",
+	"androidNativeVersion": "2.45.0",
 	"androidxAppCompatVersion": "1.6.1",
 	"description": "Unity plugin helps you to use native Didomi functionality on Android and iOS."
 }

--- a/source/Assets/Plugins/Didomi/Scripts/IOS/DidomiFramework.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/IOS/DidomiFramework.cs
@@ -64,7 +64,9 @@ namespace IO.Didomi.SDK.IOS
                 string noticeId,
                 string countryCode,
                 string regionCode,
-                bool isUnderage
+                bool isUnderage,
+                string sdkPath,
+                string apiPath
         );
 #endif
 
@@ -81,7 +83,9 @@ namespace IO.Didomi.SDK.IOS
                 initializeParameters.noticeId,
                 initializeParameters.countryCode,
                 initializeParameters.regionCode,
-                initializeParameters.isUnderage
+                initializeParameters.isUnderage,
+                initializeParameters.sdkPath,
+                initializeParameters.apiPath
                 );
 #endif
         }

--- a/source/Assets/Plugins/Didomi/Scripts/Parameters/DidomiInitializeParameters.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/Parameters/DidomiInitializeParameters.cs
@@ -79,6 +79,18 @@ namespace IO.Didomi.SDK
         public bool isUnderage { get; }
 
         /// <summary>
+        /// Base URL used to load all static files (didomi_config.json, GVL, IAB vendor list).
+        /// Defaults to the Didomi SDK CDN if null. Must use HTTPS.
+        /// </summary>
+        public string sdkPath { get; }
+
+        /// <summary>
+        /// Base URL used for all API requests (Consents API, cross-device sync, API Events).
+        /// Defaults to the Didomi API if null. Must use HTTPS.
+        /// </summary>
+        public string apiPath { get; }
+
+        /// <summary>
         /// Initialization parameters for Didomi SDK
         /// </summary>
         /// <param name="apiKey">Your API key.</param>
@@ -109,6 +121,8 @@ namespace IO.Didomi.SDK
         /// Keep null to let the Didomi SDK determine the user region.
         /// Ignored if countryCode is not set.</param>
         /// <param name="isUnderage">If set to true, the SDK will only display the underage notice (false by default).</param>
+        /// <param name="sdkPath">Base URL for static files. Defaults to Didomi CDN if null. Must use HTTPS.</param>
+        /// <param name="apiPath">Base URL for API requests. Defaults to Didomi API if null. Must use HTTPS.</param>
         public DidomiInitializeParameters(
             string apiKey,
             string localConfigurationPath = null,
@@ -121,7 +135,9 @@ namespace IO.Didomi.SDK
             bool androidTvEnabled = false,
             string countryCode = null,
             string regionCode = null,
-            bool isUnderage = false
+            bool isUnderage = false,
+            string sdkPath = null,
+            string apiPath = null
         ) {
             this.apiKey = apiKey;
             this.localConfigurationPath = localConfigurationPath;
@@ -135,6 +151,8 @@ namespace IO.Didomi.SDK
             this.countryCode = countryCode;
             this.regionCode = regionCode;
             this.isUnderage = isUnderage;
+            this.sdkPath = sdkPath;
+            this.apiPath = apiPath;
         }
     }
 }


### PR DESCRIPTION
Adds two optional parameters to DidomiInitializeParameters to allow overriding the default Didomi CDN and API base URLs:

- `sdkPath`: overrides the base URL for static files (config, GVL, IAB vendor list)
- `apiPath`: overrides the base URL for API requests (consent sync, API events)

Both values must use HTTPS. Requires iOS SDK 2.45.0 / Android SDK 2.45.0.