### PR TITLE
feat: add showWidget and hideWidget events

### DIFF
--- a/source/Assets/Plugins/Didomi/IOS/Didomi.mm
+++ b/source/Assets/Plugins/Didomi/IOS/Didomi.mm
@@ -834,7 +834,7 @@ void removeSyncAcknowledgedCallback(int eventIndex) {
     syncAcknowledgedCallbacks[@(eventIndex)] = nil;
 }
 
-void addEventListener( void (*event_listener_handler) (int, char *), void (*sync_ready_event_listener_handler) (int, char *, int, int), void (*integration_error_event_listener_handler) (int, char *, char *))
+void addEventListener( void (*event_listener_handler) (int, char *), void (*sync_ready_event_listener_handler) (int, char *, int, int), void (*integration_error_event_listener_handler) (int, char *, char *), void (*show_widget_event_listener_handler) (int, char *, char *))
 {
 
     if(eventListener==nil)
@@ -1104,6 +1104,23 @@ void addEventListener( void (*event_listener_handler) (int, char *), void (*sync
         char * reason = convertNSStringToCString([event reason]);
 
         integration_error_event_listener_handler(DDMEventTypeIntegrationError, integrationName, reason);
+
+    };
+
+    // The iOS SDK exposes the property as `widgetID` while the Android SDK uses `widgetId`.
+    // It is mapped to `widgetId` on the C# side so that both platforms share the same event class.
+    eventListener.onShowWidget = ^(DDMShowWidgetEvent * event){
+
+        char * widgetId = convertNSStringToCString([event widgetID]);
+        char * layerName = convertNSStringToCString([event layerName]);
+
+        show_widget_event_listener_handler(DDMEventTypeShowWidget, widgetId, layerName);
+
+    };
+
+    eventListener.onHideWidget = ^(DDMHideWidgetEvent * event){
+
+        event_listener_handler(DDMEventTypeHideWidget, NULL);
 
     };
 

--- a/source/Assets/Plugins/Didomi/Resources/package.json
+++ b/source/Assets/Plugins/Didomi/Resources/package.json
@@ -2,7 +2,7 @@
 	"name": "com.didomi.unityplugin",
 	"displayName": "Native Didomi",
 	"agentName": "Didomi Unity SDK",
-	"version": "2.28.0",
+	"version": "2.29.0",
 	"iosNativeVersion": "2.47.0",
 	"androidNativeVersion": "2.47.0",
 	"androidxAppCompatVersion": "1.6.1",

--- a/source/Assets/Plugins/Didomi/Resources/package.json
+++ b/source/Assets/Plugins/Didomi/Resources/package.json
@@ -3,8 +3,8 @@
 	"displayName": "Native Didomi",
 	"agentName": "Didomi Unity SDK",
 	"version": "2.28.0",
-	"iosNativeVersion": "2.46.0",
-	"androidNativeVersion": "2.46.0",
+	"iosNativeVersion": "2.47.0",
+	"androidNativeVersion": "2.47.0",
 	"androidxAppCompatVersion": "1.6.1",
 	"description": "Unity plugin helps you to use native Didomi functionality on Android and iOS."
 }

--- a/source/Assets/Plugins/Didomi/Scripts/Android/EventListenerProxy.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/Android/EventListenerProxy.cs
@@ -323,6 +323,20 @@ namespace IO.Didomi.SDK.Android
             // An error occurred during integration process
         }
 
+        public void showWidget(AndroidJavaObject @event)
+        {
+            var ShowWidgetEvent = ConvertToShowWidgetEvent(@event);
+
+            _eventListener.OnShowWidget(ShowWidgetEvent);
+            // A widget is being shown
+        }
+
+        public void hideWidget(AndroidJavaObject @event)
+        {
+            _eventListener.OnHideWidget(new HideWidgetEvent());
+            // A widget is being hidden
+        }
+
         private static ErrorEvent ConvertToErrorEvent(AndroidJavaObject @event)
         {
             var errorMessage = GetErrorMessage(@event);
@@ -455,6 +469,14 @@ namespace IO.Didomi.SDK.Android
             return new IntegrationErrorEvent(integrationName, reason);
         }
 
+        private static ShowWidgetEvent ConvertToShowWidgetEvent(AndroidJavaObject @event)
+        {
+            var widgetId = GetWidgetId(@event);
+            var layerName = GetLayerName(@event);
+
+            return new ShowWidgetEvent(widgetId, layerName);
+        }
+
         private static string GetPurposeId(AndroidJavaObject @event)
         {
            return AndroidObjectMapper.GetMethodStringValue(@event, "getPurposeId");
@@ -513,6 +535,16 @@ namespace IO.Didomi.SDK.Android
         private static string GetIntegrationName(AndroidJavaObject @event)
         {
             return AndroidObjectMapper.GetMethodStringValue(@event, "getIntegrationName");
+        }
+
+        private static string GetWidgetId(AndroidJavaObject @event)
+        {
+            return AndroidObjectMapper.GetMethodStringValue(@event, "getWidgetId");
+        }
+
+        private static string GetLayerName(AndroidJavaObject @event)
+        {
+            return AndroidObjectMapper.GetMethodStringValue(@event, "getLayerName");
         }
     }
 }

--- a/source/Assets/Plugins/Didomi/Scripts/Events/DidomiEventListener.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/Events/DidomiEventListener.cs
@@ -190,6 +190,14 @@ namespace IO.Didomi.SDK.Events
         /// An error occurred in the Didomi SDK integration
         /// </summary>
         public event EventHandler<IntegrationErrorEvent> IntegrationError;
+        /// <summary>
+        /// A widget has been displayed
+        /// </summary>
+        public event EventHandler<ShowWidgetEvent> ShowWidget;
+        /// <summary>
+        /// A widget has been hidden
+        /// </summary>
+        public event EventHandler<HideWidgetEvent> HideWidget;
 
         public DidomiEventListener() { }
 
@@ -453,6 +461,18 @@ namespace IO.Didomi.SDK.Events
         {
             IntegrationError?.Invoke(this, @event);
             // An error occurred during Didomi SDK integration
+        }
+
+        public void OnShowWidget(ShowWidgetEvent @event)
+        {
+            ShowWidget?.Invoke(this, @event);
+            // A widget is being shown
+        }
+
+        public void OnHideWidget(HideWidgetEvent @event)
+        {
+            HideWidget?.Invoke(this, @event);
+            // A widget is being hidden
         }
     }
 }

--- a/source/Assets/Plugins/Didomi/Scripts/Events/HideWidgetEvent.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/Events/HideWidgetEvent.cs
@@ -1,0 +1,8 @@
+namespace IO.Didomi.SDK.Events
+{
+    /// <summary>
+    /// A widget has been hidden
+    /// </summary>
+    public class HideWidgetEvent : Event {
+    }
+}

--- a/source/Assets/Plugins/Didomi/Scripts/Events/HideWidgetEvent.cs.meta
+++ b/source/Assets/Plugins/Didomi/Scripts/Events/HideWidgetEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f552304fd86a4c96b56c2ee56496d87b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/Assets/Plugins/Didomi/Scripts/Events/ShowWidgetEvent.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/Events/ShowWidgetEvent.cs
@@ -1,0 +1,40 @@
+namespace IO.Didomi.SDK.Events
+{
+    /// <summary>
+    /// A widget has been displayed
+    /// </summary>
+    public class ShowWidgetEvent : Event
+    {
+        private string widgetId;
+        private string layerName;
+
+        public ShowWidgetEvent(
+            string widgetId,
+            string layerName
+        )
+        {
+            this.widgetId = widgetId;
+            this.layerName = layerName;
+        }
+
+        /// <summary>
+        /// Identifier of the widget that was displayed, as resolved by the Rules Engine.
+        /// Null if unknown.
+        /// </summary>
+        /// <returns></returns>
+        public string getWidgetId()
+        {
+            return widgetId;
+        }
+
+        /// <summary>
+        /// Name of the layer at which the widget was displayed.
+        /// Null if unknown or default.
+        /// </summary>
+        /// <returns></returns>
+        public string getLayerName()
+        {
+            return layerName;
+        }
+    }
+}

--- a/source/Assets/Plugins/Didomi/Scripts/Events/ShowWidgetEvent.cs.meta
+++ b/source/Assets/Plugins/Didomi/Scripts/Events/ShowWidgetEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a8832ed095b48a89b129ef8916d8fc1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/Assets/Plugins/Didomi/Scripts/IOS/DDMEventType.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/IOS/DDMEventType.cs
@@ -51,6 +51,10 @@ namespace Assets.Plugins.Scripts.IOS
         DDMEventTypeDCSSignatureReady = 41,
         DDMEventTypeDCSSignatureError = 42,
         DDMEventTypeIntegrationError = 43,
+        // Values 44 to 46 are used by events that are not exposed in the Unity SDK
+        // (ConsentChangedWithObject, OnConsentUIReady, OnConsentUIFinished).
+        DDMEventTypeShowWidget = 47,
+        DDMEventTypeHideWidget = 48,
         DDMEventTypeError = 1000,
     };
 }

--- a/source/Assets/Plugins/Didomi/Scripts/IOS/DidomiFramework.cs
+++ b/source/Assets/Plugins/Didomi/Scripts/IOS/DidomiFramework.cs
@@ -463,9 +463,11 @@ namespace IO.Didomi.SDK.IOS
 
         public delegate void OnIntegrationErrorEventListenerDelegate(int eventType, string integrationName, string reason);
 
+        public delegate void OnShowWidgetEventListenerDelegate(int eventType, string widgetId, string layerName);
+
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal")]
-        private static extern void addEventListener(OnEventListenerDelegate eventListenerDelegate, OnSyncReadyEventListenerDelegate syncReadyEventListenerDelegate, OnIntegrationErrorEventListenerDelegate integrationErrorEventListenerDelegate);
+        private static extern void addEventListener(OnEventListenerDelegate eventListenerDelegate, OnSyncReadyEventListenerDelegate syncReadyEventListenerDelegate, OnIntegrationErrorEventListenerDelegate integrationErrorEventListenerDelegate, OnShowWidgetEventListenerDelegate showWidgetEventListenerDelegate);
 
         [DllImport("__Internal")]
         private static extern int syncAcknowledgedCallback(int callbackIndex);
@@ -478,7 +480,7 @@ namespace IO.Didomi.SDK.IOS
         {
             eventListenerInner = eventListener;
 #if (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
-            addEventListener(CallOnEventListenerDelegate, CallOnSyncReadyEventListenerDelegate, CallOnIntegrationErrorEventListenerDelegate);
+            addEventListener(CallOnEventListenerDelegate, CallOnSyncReadyEventListenerDelegate, CallOnIntegrationErrorEventListenerDelegate, CallOnShowWidgetEventListenerDelegate);
 #endif
         }
 
@@ -616,6 +618,9 @@ namespace IO.Didomi.SDK.IOS
                 case DDMEventType.DDMEventTypeDCSSignatureReady:
                     eventListenerInner.OnDcsSignatureReady(new DcsSignatureReadyEvent());
                     break;
+                case DDMEventType.DDMEventTypeHideWidget:
+                    eventListenerInner.OnHideWidget(new HideWidgetEvent());
+                    break;
                 default:
                     break;
             }
@@ -658,6 +663,21 @@ namespace IO.Didomi.SDK.IOS
                     eventListenerInner.OnIntegrationError(new IntegrationErrorEvent(
                         integrationName,
                         reason
+                    ));
+                    break;
+            }
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(OnShowWidgetEventListenerDelegate))]
+        static void CallOnShowWidgetEventListenerDelegate(int eventType, string widgetId, string layerName)
+        {
+            DDMEventType eventTypeEnum = (DDMEventType)eventType;
+            switch (eventTypeEnum)
+            {
+                case DDMEventType.DDMEventTypeShowWidget:
+                    eventListenerInner.OnShowWidget(new ShowWidgetEvent(
+                        widgetId,
+                        layerName
                     ));
                     break;
             }

--- a/source/Assets/Scripts/DidomiSample/DemoGUI.cs
+++ b/source/Assets/Scripts/DidomiSample/DemoGUI.cs
@@ -792,6 +792,8 @@ public class DemoGUI : MonoBehaviour
         eventListener.SyncError += EventListener_SyncError;
         eventListener.LanguageUpdated += EventListener_LanguageUpdated;
         eventListener.LanguageUpdateFailed += EventListener_LanguageUpdateFailed;
+        eventListener.ShowWidget += EventListener_ShowWidget;
+        eventListener.HideWidget += EventListener_HideWidget;
 
         Didomi.GetInstance().AddEventListener(eventListener);
     }
@@ -956,6 +958,16 @@ public class DemoGUI : MonoBehaviour
     private void EventListener_LanguageUpdateFailed(object sender, LanguageUpdateFailedEvent e)
     {
         message += "\nEvent: LanguageUpdateFailed, Reason=" + e.getReason();
+    }
+
+    private void EventListener_ShowWidget(object sender, ShowWidgetEvent e)
+    {
+        message += "\nEvent: ShowWidget, WidgetId=" + e.getWidgetId() + ", LayerName=" + e.getLayerName();
+    }
+
+    private void EventListener_HideWidget(object sender, HideWidgetEvent e)
+    {
+        message += "\nEvent: HideWidget";
     }
 
     private void VendorStatusListener_VendorStatusChanged(object sender, CurrentUserStatus.VendorStatus status)


### PR DESCRIPTION
Updates the native SDKs to 2.47.0 and exposes the new widget events, mirroring didomi/react-native#186.

## Changes

**Native SDKs → 2.47.0**
- `iosNativeVersion` and `androidNativeVersion` in `Resources/package.json`. That file is the single source of truth: `DidomiPaths` builds the XCFramework download URL from it, and `PostProcessor` injects the Android dependency from it, so there are no other version pins to update.
- Plugin version → 2.29.0 (same file, also used for the SDK user agent on both platforms)

**Widget events**
- New `ShowWidgetEvent` (`widgetId`, `layerName`) and `HideWidgetEvent`, exposed as `ShowWidget` / `HideWidget` on `DidomiEventListener`
- Android: `showWidget` / `hideWidget` in `EventListenerProxy.cs`, with a `ConvertToShowWidgetEvent` helper following the existing `integrationError` pattern
- iOS: `DDMEventTypeShowWidget` / `DDMEventTypeHideWidget`, `onShowWidget` / `onHideWidget` closures in `Didomi.mm`, and a new `OnShowWidgetEventListenerDelegate` P/Invoke callback in `DidomiFramework.cs`
- Events registered in the sample app (`DemoGUI.cs`)

### Two things worth a reviewer's attention

**The iOS enum is not contiguous.** The native values are **47 and 48**, not 44/45 — slots 44 to 46 belong to `ConsentChangedWithObject` and two UI events that Unity does not expose. The iOS header carries the note *"Please keep the current order because of Unity bridge."* Appending sequentially would have compiled fine and silently misrouted events at runtime, so the values were read off the real 2.47.0 header. A comment in `DDMEventType.cs` records why the gap is there.

**Android's proxy has a hard runtime contract.** `AndroidJavaProxy` requires every method of the Java interface to be implemented, so `showWidget` / `hideWidget` were not optional once the SDK moved to 2.47.0 — omitting them would break the whole listener.

### Cross-platform naming

The iOS SDK exposes the property as `widgetID`, Android as `widgetId`. Both bridges map it to `widgetId` so a single C# event class fits both platforms. Noted in a comment at each site, same approach as the React Native PR.

Since `showWidget` carries two strings it uses a dedicated callback, like `integrationError`. `hideWidget` has no payload and reuses the generic handler.

## Verification

- **Unity 6000.3.5f1 batchmode compile**: clean, no errors. The new types, the `add_` / `remove_` accessors for both events, and the new P/Invoke callback are all present in the compiled `DidomiAssembly.dll`.
- **iOS**: `Didomi.mm` passes `clang -fsyntax-only` against the real 2.47.0 XCFramework headers with no errors and no warnings, confirming `onShowWidget`, `onHideWidget` and the `widgetID` property.
- **Android**: `EventListenerProxy` implements all 46 methods of the 2.47.0 `DidomiEventListener` interface, verified against the published AAR.

## Not covered by automated tests

End-to-end event delivery needs a web-rendered notice that actually serves a widget, and the existing suites are on-device integration tests with no API to trigger one — so no test was added that would assert nothing. Same limitation documented in the React Native and Flutter PRs. **Worth a manual check against a widget-serving notice configuration before release.**