### PR TITLE
fix: isolate Gradle config when running Android tests

### DIFF
--- a/source/scripts/runAndroidTests.sh
+++ b/source/scripts/runAndroidTests.sh
@@ -13,6 +13,12 @@ UNITY_PATH=$(awk -F= '/^editor/ {print $2}' $scriptsDir/unity.properties)
 RESULTS_PATH="artifacts/android-test-results.xml"
 LOG_PATH="artifacts/androidTestsRun.log"
 
+# Use a dedicated Gradle home so the build ignores the user's global
+# ~/.gradle/gradle.properties. Settings there (org.gradle.java.home pointing at a
+# JDK newer than Unity's Gradle supports, configuration-cache, configureondemand)
+# break the Android player build. Keeps local runs consistent with CI.
+export GRADLE_USER_HOME="$scriptsDir/../artifacts/.gradle"
+
 # Check for any Android emulator / device
 connected_devices=$(adb devices | grep -v "List" | grep "device$")
 if [ -z "$connected_devices" ]; then


### PR DESCRIPTION
The Android test script fails before running a single test.

## Problem

`source/scripts/runAndroidTests.sh` aborts during the Android player build, in Gradle build-script evaluation:

```
Script .../Gradle/launcher/setupSymbols.gradle line: 6
> BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_'
  Unsupported class file major version 69
BUILD FAILED in 11s
```

That cascades to `Player build failed` → `TestLaunchFailedException` → `Test run completed. Exiting with code 3 (RunError)`. No tests execute.

### Root cause

Unity 6000.x launches **Gradle 8.13** using its bundled **JDK 17**. But a developer's global `~/.gradle/gradle.properties` may set:

```
org.gradle.java.home = /Applications/Android Studio.app/Contents/jbr/Contents/Home
```

Android Studio's JBR is **JDK 25** = class file **major version 69**. Gradle honours `org.gradle.java.home` and forks its daemon onto that JVM, which Gradle 8.13's Groovy compiler cannot read — so it dies while compiling the build scripts.

The second reported failure (`project ':launcher' does not specify compileSdk`) is a cascade of the same problem: `build.gradle` never got evaluated, so AGP saw no config.

## Fix

Point `GRADLE_USER_HOME` at a project-local directory so the build stops reading the developer's global Gradle config.

Side benefits:
- Also neutralises `org.gradle.configuration-cache` / `org.gradle.configureondemand`, which Unity's generated project does not support.
- Makes local runs behave like CI, which has no personal `gradle.properties`.
- The directory is already covered by the existing `.gradle/` rule in `source/.gitignore`, so nothing new is committed.

## Verification

Gradle daemon JVM resolution, same Gradle launcher, with and without the isolated home:

| Gradle home | Daemon JVM |
| --- | --- |
| Default (reads global config) | Android Studio JBR — **Java 25** (major 69) ❌ |
| Isolated (this change) | Unity bundled OpenJDK — **Java 17** ✅ |

- `Unsupported class file major version 69`: **0 occurrences** after the change.
- Build no longer dies at 11s; the Gradle daemon runs as `GradleDaemon 8.13` on Unity's OpenJDK with no `org.gradle.java.home` fork.
- Android tests pass.

Only `runAndroidTests.sh` is touched — it is the only script that drives a Gradle build.